### PR TITLE
Add general measurement entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ ce_wannsee_xrd_xy_parser = "nomad_chemical_energy.parsers:ce_wannsee_xrd_xy_pars
 dlr_ec_cv_parser = "nomad_chemical_energy.parsers:dlr_ec_cv_parser"
 dlr_ec_cp_parser = "nomad_chemical_energy.parsers:dlr_ec_cp_parser"
 dlr_ec_eis_parser = "nomad_chemical_energy.parsers:dlr_ec_eis_parser"
+hzb_general_measurement_parser = "nomad_chemical_energy.parsers:hzb_general_measurement_parser"
 
 necc_find_app = "nomad_chemical_energy.apps:necc_find_app"
 necc_compare_app = "nomad_chemical_energy.apps:necc_compare_app"

--- a/src/nomad_chemical_energy/parsers/__init__.py
+++ b/src/nomad_chemical_energy/parsers/__init__.py
@@ -99,6 +99,13 @@ class CatlabParserEntryPoint(ParserEntryPoint):
         return CatlabParser(**self.dict())
 
 
+class GeneralMeasurementParserEntryPoint(ParserEntryPoint):
+
+    def load(self):
+        from nomad_chemical_energy.parsers.hzb_general_parser import GeneralMeasurementParser
+        return GeneralMeasurementParser(**self.dict())
+
+
 ce_necc_xlsx_parser = CENECCxlsxParserEntryPoint(
     name='CENECCxlsxParser',
     description='Parser for CENECC xls files',
@@ -196,4 +203,10 @@ hzb_catlab_parser = CatlabParserEntryPoint(
     description='Parser for Catlab files',
     mainfile_name_re='^.*CatID[0-9].*#.*$',
     mainfile_mime_re='.*/.*'
+)
+
+hzb_general_measurement_parser = GeneralMeasurementParserEntryPoint(
+    name='GeneralMeasurementParser',
+    description='Parser for general measurement files starting with a sample id',
+    mainfile_name_re='^.*[A-Z][a-z][A-Z][a-z]\d{4}(-.*)?\.(?!.*\.*pynb$|.*\.*py$|.*\.*archive\.json$|.*\.*json$)[a-zA-Z0-9.]+$',
 )

--- a/src/nomad_chemical_energy/parsers/hzb_general_parser.py
+++ b/src/nomad_chemical_energy/parsers/hzb_general_parser.py
@@ -76,8 +76,9 @@ class GeneralMeasurementParser(MatchingParser):
         # eid = get_entry_id_from_file_name(file_name_archive, archive)
         # ref = get_reference(archive.metadata.upload_id, eid)
         # if not new_entry_created:
-        #     entry = update_general_measurement_entries(entry, eid, archive, logger, TxtMeasurement())
-        #     create_archive(entry, archive, file_name_archive, overwrite=True)
+        #     new_entry = update_general_measurement_entries(entry, eid, archive, logger, TxtMeasurement())
+        #     if new_entry is not None:
+        #         create_archive(new_entry, archive, file_name_archive, overwrite=True)
         # archive.data = ParsedTxtFile(activity=ref)
         # archive.metadata.entry_name = file_name.split(".")[0].replace("-", " ")
 

--- a/src/nomad_chemical_energy/parsers/hzb_general_parser.py
+++ b/src/nomad_chemical_energy/parsers/hzb_general_parser.py
@@ -70,3 +70,42 @@ class GeneralMeasurementParser(MatchingParser):
         archive.data = ParsedGeneralMeasurementFile(activity=ref)
         archive.metadata.entry_name = file_name.split(".")[0].replace("-", " ")
 
+        # TODO for new measurement parsers that should replace GeneralMeasurement entries you can use this code inside the parser
+        # file_name_archive = f'{file_name}.archive.json'
+        # new_entry_created = create_archive(entry, archive, file_name_archive)
+        # eid = get_entry_id_from_file_name(file_name_archive, archive)
+        # ref = get_reference(archive.metadata.upload_id, eid)
+        # if not new_entry_created:
+        #     entry = update_general_measurement_entries(entry, eid, archive, logger, TxtMeasurement())
+        #     create_archive(entry, archive, file_name_archive, overwrite=True)
+        # archive.data = ParsedTxtFile(activity=ref)
+        # archive.metadata.entry_name = file_name.split(".")[0].replace("-", " ")
+
+
+def update_general_measurement_entries(entry, entry_id, archive, logger, entry_class):
+    from nomad.search import search
+    from nomad import files
+    query = {
+        'entry_id': entry_id,
+    }
+    search_result = search(
+        owner='all',
+        query=query,
+        user_id=archive.metadata.main_author.user_id)
+    entry_type = search_result.data[0].get('entry_type') if len(search_result.data) == 1 else None
+    if entry_type == 'HZB_GeneralMeasurement':
+        new_entry_dict = entry.m_to_dict()
+        res = search_result.data[0] if len(search_result.data) == 1 else None
+        try:
+            # Open Archives
+            with files.UploadFiles.get(upload_id=res["upload_id"]).read_archive(
+                    entry_id=res["entry_id"]) as archive:
+                entry_id = res["entry_id"]
+                entry_data = archive[entry_id]["data"]
+                entry_data.pop('m_def', None)
+                new_entry_dict.update(entry_data)
+        except Exception as e:
+            logger.error("Error in processing data: ", e)
+
+        new_entry = entry_class.m_from_dict(new_entry_dict)
+        return new_entry

--- a/src/nomad_chemical_energy/parsers/hzb_general_parser.py
+++ b/src/nomad_chemical_energy/parsers/hzb_general_parser.py
@@ -1,0 +1,72 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from nomad.datamodel import EntryArchive
+from nomad.metainfo import (
+    Quantity,
+)
+from nomad.parsing import MatchingParser
+from nomad.datamodel.data import (
+    EntryData,
+)
+
+from nomad.datamodel.metainfo.annotations import (
+    ELNAnnotation,
+)
+
+from nomad.datamodel.metainfo.basesections import (
+    Activity,
+)
+
+from baseclasses.helper.utilities import (create_archive, get_entry_id_from_file_name,
+                                          get_reference, set_sample_reference)
+
+from nomad_chemical_energy.schema_packages.hzb_general_measurement_package import (HZB_GeneralMeasurement)
+
+
+class ParsedGeneralMeasurementFile(EntryData):
+
+    activity = Quantity(
+        type=Activity,
+        a_eln=ELNAnnotation(
+            component='ReferenceEditQuantity',
+        )
+    )
+
+
+class GeneralMeasurementParser(MatchingParser):
+
+    def parse(self, mainfile: str, archive: EntryArchive, logger) -> None:
+
+        file_name = mainfile.split('/')[-1]
+        sample_id = file_name.split(".")[0].split("-")[0]
+
+        entry = HZB_GeneralMeasurement()
+        entry.name = file_name
+        entry.data_file = file_name
+
+        archive.metadata.entry_name = file_name
+        set_sample_reference(archive, entry, sample_id)
+        file_name_archive = f'{file_name}.archive.json'
+        create_archive(entry, archive, file_name_archive)
+
+        eid = get_entry_id_from_file_name(file_name_archive, archive)
+        ref = get_reference(archive.metadata.upload_id, eid)
+        archive.data = ParsedGeneralMeasurementFile(activity=ref)
+        archive.metadata.entry_name = file_name.split(".")[0].replace("-", " ")
+

--- a/src/nomad_chemical_energy/parsers/hzb_general_parser.py
+++ b/src/nomad_chemical_energy/parsers/hzb_general_parser.py
@@ -61,7 +61,7 @@ class GeneralMeasurementParser(MatchingParser):
         entry.data_file = file_name
 
         archive.metadata.entry_name = file_name
-        set_sample_reference(archive, entry, sample_id)
+        set_sample_reference(archive, entry, sample_id, archive.metadata.upload_id)
         file_name_archive = f'{file_name}.archive.json'
         create_archive(entry, archive, file_name_archive)
 

--- a/src/nomad_chemical_energy/parsers/hzb_general_parser.py
+++ b/src/nomad_chemical_energy/parsers/hzb_general_parser.py
@@ -93,19 +93,20 @@ def update_general_measurement_entries(entry, entry_id, archive, logger, entry_c
         query=query,
         user_id=archive.metadata.main_author.user_id)
     entry_type = search_result.data[0].get('entry_type') if len(search_result.data) == 1 else None
-    if entry_type == 'HZB_GeneralMeasurement':
-        new_entry_dict = entry.m_to_dict()
-        res = search_result.data[0] if len(search_result.data) == 1 else None
-        try:
-            # Open Archives
-            with files.UploadFiles.get(upload_id=res["upload_id"]).read_archive(
-                    entry_id=res["entry_id"]) as archive:
-                entry_id = res["entry_id"]
-                entry_data = archive[entry_id]["data"]
-                entry_data.pop('m_def', None)
-                new_entry_dict.update(entry_data)
-        except Exception as e:
-            logger.error("Error in processing data: ", e)
+    if entry_type != 'HZB_GeneralMeasurement':
+        return None
+    new_entry_dict = entry.m_to_dict()
+    res = search_result.data[0]
+    try:
+        # Open Archives
+        with files.UploadFiles.get(upload_id=res["upload_id"]).read_archive(
+                entry_id=res["entry_id"]) as archive:
+            entry_id = res["entry_id"]
+            entry_data = archive[entry_id]["data"]
+            entry_data.pop('m_def', None)
+            new_entry_dict.update(entry_data)
+    except Exception as e:
+        logger.error("Error in processing data: ", e)
 
-        new_entry = entry_class.m_from_dict(new_entry_dict)
-        return new_entry
+    new_entry = entry_class.m_from_dict(new_entry_dict)
+    return new_entry

--- a/src/nomad_chemical_energy/schema_packages/hzb_general_measurement_package.py
+++ b/src/nomad_chemical_energy/schema_packages/hzb_general_measurement_package.py
@@ -1,0 +1,45 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from nomad.metainfo import (
+    SchemaPackage,
+    Section)
+from nomad.datamodel.data import EntryData
+
+from baseclasses.chemical_energy import (
+    GeneralMeasurement,
+)
+
+m_package = SchemaPackage()
+
+# %% ####################### Entities
+
+
+class HZB_GeneralMeasurement(GeneralMeasurement, EntryData):
+    m_def = Section(
+        a_eln=dict(
+            hide=['lab_id', 'location', 'steps', 'atmosphere', 'instruments', 'results'],
+            properties=dict(
+                order=[])),
+    )
+
+    def normalize(self, archive, logger):
+        super(HZB_GeneralMeasurement, self).normalize(archive, logger)
+
+
+m_package.__init_metainfo__()


### PR DESCRIPTION
This PR solves https://github.com/nomad-hzb/nomad-chemical-energy/issues/20

I decided to exclude .py .pynb and .archive.json from possible file endings. Because I could not solve it otherwise I also  excluded .json files.

For files who do not match any other parser the HZB_GeneralMeasurement entry is created. This entry links to the sample if the filename is SampleID.fileending or SampleID-somename.fileending and the sample with the specified ID already exists.

For already existing parsers the name has to be SampleID.fileending otherwise the sample gets not linked automatically. I am not sure if I should change that behavior in all existing parsers. Maybe you can comment on that.