### PR TITLE
Add parsing for necc excel with 8 tabs

### DIFF
--- a/src/nomad_chemical_energy/parsers/ce_necc_parser.py
+++ b/src/nomad_chemical_energy/parsers/ce_necc_parser.py
@@ -68,13 +68,25 @@ class NECCXlsxParser(MatchingParser):
         if not is_mainfile_super:
             return False
         excel_sheets = pd.ExcelFile(filename).sheet_names
-        required_sheets = [
+        required_sheets_v1 = [
             'Catalyst details',
             'Experimental details',
             'Raw Data',
             'Results',
         ]
-        return all(sheet in excel_sheets for sheet in required_sheets)
+        required_sheets_v2 = [
+            'Experimental Details',
+            'Time_Calc',
+            'FID Data',
+            'TCD Data',
+            'Pot Data',
+            'Thermo Data',
+            'GC Calc',
+            'Results',
+        ]
+        is_v1_excel = all(sheet in excel_sheets for sheet in required_sheets_v1)
+        is_v2_excel = all(sheet in excel_sheets for sheet in required_sheets_v2)
+        return is_v1_excel or is_v2_excel
 
     def parse(self, mainfile: str, archive: EntryArchive, logger) -> None:
         file = mainfile.split('/')[-1]
@@ -83,7 +95,7 @@ class NECCXlsxParser(MatchingParser):
 
         xls_file = pd.ExcelFile(mainfile)
         num_sheets = len(xls_file.sheet_names)
-        if num_sheets != 4:
+        if num_sheets != 4 and num_sheets != 8:
             return
         entry = CE_NECC_EC_GC(data_file=file)
 

--- a/src/nomad_chemical_energy/parsers/ce_necc_parser.py
+++ b/src/nomad_chemical_energy/parsers/ce_necc_parser.py
@@ -95,7 +95,7 @@ class NECCXlsxParser(MatchingParser):
 
         xls_file = pd.ExcelFile(mainfile)
         num_sheets = len(xls_file.sheet_names)
-        if num_sheets != 4 and num_sheets != 8:
+        if num_sheets not in (4, 8):
             return
         entry = CE_NECC_EC_GC(data_file=file)
 

--- a/src/nomad_chemical_energy/schema_packages/ce_necc_package.py
+++ b/src/nomad_chemical_energy/schema_packages/ce_necc_package.py
@@ -216,6 +216,13 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
         )
         return fig
 
+    def get_cleaned_df(self, data, column_list):
+        string_col_names = [col for col in data.columns if isinstance(col, str)]
+        existing_columns = [col for col in string_col_names if any(col.startswith(prefix) for prefix in column_list)]
+        cleaned_df = data.loc[:, existing_columns]
+        cleaned_df.dropna(axis=0, how='all', inplace=True)
+        return cleaned_df
+
     def normalize(self, archive, logger):
         if self.data_file:
             with archive.m_context.raw_file(self.data_file, 'rb') as f:
@@ -229,7 +236,6 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                     experimental_properties_dict = read_properties(xls_file)
                     self.properties = NECCExperimentalProperties()
                     for attribute_name, value in experimental_properties_dict.items():
-                        # TODO setattr should be avoided but I don't know better way when having that many attributes
                         setattr(self.properties, attribute_name, value)
 
                 if (
@@ -237,7 +243,31 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                     or not self.gaschromatographies
                     or not self.potentiometry
                 ):
-                    data = pd.read_excel(xls_file, sheet_name='Raw Data', header=1)
+                    gc_columns = ['Experiment name', 'Date', 'Time ', 'Gas type', 'RT', 'area', 'ppm value']
+                    pot_columns = ['time/s', 'I/mA', 'Ewe/V', 'Ece/V', 'Ewe-Ece/V']
+                    thermo_columns = ['Date', 'Time Stamp Local', 'bar(g)', 'øC  cathode', 'øC  anode']
+                    if len(xls_file.sheet_names) == 4:
+                        data = pd.read_excel(xls_file, sheet_name='Raw Data', header=1)
+                        results_data = pd.read_excel(xls_file, sheet_name='Results', header=0)
+
+                        gc_data = self.get_cleaned_df(data, gc_columns)
+                        pot_data = self.get_cleaned_df(data, pot_columns)
+                        data.columns = data.iloc[1]     # thermo column names are in second row
+                        thermo_data = self.get_cleaned_df(data[2:], thermo_columns)
+                    else:
+                        pot_data = pd.read_excel(xls_file, sheet_name='Pot Data')
+                        thermo_data = pd.read_excel(xls_file, sheet_name='Thermo Data')
+                        fid_data = pd.read_excel(xls_file, sheet_name='FID Data')
+                        tcd_data = pd.read_excel(xls_file, sheet_name='TCD Data')
+                        results_data = pd.read_excel(xls_file, sheet_name='GC Calc', header=0)
+
+                        pot_data = self.get_cleaned_df(pot_data, pot_columns)
+                        thermo_data = self.get_cleaned_df(thermo_data, thermo_columns)
+                        fid_data = self.get_cleaned_df(fid_data, gc_columns)
+                        tcd_data = self.get_cleaned_df(tcd_data, gc_columns)
+                        gc_data = pd.merge(fid_data, tcd_data, on=['Date', 'Time '], how='inner')
+
+                    results_data.dropna(axis=0, how='any', inplace=True)
 
                     from nomad_chemical_energy.schema_packages.file_parser.necc_excel_parser import (
                         read_gaschromatography_data,
@@ -251,7 +281,7 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                         retention_times,
                         areas,
                         ppms,
-                    ) = read_gaschromatography_data(data)
+                    ) = read_gaschromatography_data(gc_data)
                     if datetimes.size > 0:
                         start_time = datetimes.iat[0]
                         end_time = datetimes.iat[-1]
@@ -283,7 +313,7 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                         working_electrode_potential,
                         counter_electrode_potential,
                         ewe_ece_difference,
-                    ) = read_potentiostat_data(data)
+                    ) = read_potentiostat_data(pot_data)
                     if start_time is None or end_time is None:
                         start_time = datetimes.iat[0]
                         end_time = datetimes.iat[-1]
@@ -297,11 +327,9 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                     from nomad_chemical_energy.schema_packages.file_parser.necc_excel_parser import (
                         read_thermocouple_data,
                     )
-
-                    data.columns = data.iloc[1]
                     try:
                         datetimes, pressure, temperature_cathode, temperature_anode = (
-                            read_thermocouple_data(data.iloc[2:], start_time, end_time)
+                            read_thermocouple_data(thermo_data, start_time, end_time)
                         )
                         self.thermocouple = ThermocoupleMeasurement(
                             datetime=datetimes.to_list(),
@@ -325,7 +353,7 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                         cell_current,
                         cell_voltage,
                         gas_measurements,
-                    ) = read_results_data(xls_file)
+                    ) = read_results_data(results_data)
                     self.fe_results = PotentiometryGasChromatographyResults(
                         datetime=datetimes.to_list(),
                         total_flow_rate=total_flow_rate,

--- a/src/nomad_chemical_energy/schema_packages/ce_necc_package.py
+++ b/src/nomad_chemical_energy/schema_packages/ce_necc_package.py
@@ -218,7 +218,11 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
 
     def get_cleaned_df(self, data, column_list):
         string_col_names = [col for col in data.columns if isinstance(col, str)]
-        existing_columns = [col for col in string_col_names if any(col.startswith(prefix) for prefix in column_list)]
+        existing_columns = [
+            col
+            for col in string_col_names
+            if any(col.startswith(prefix) for prefix in column_list)
+        ]
         cleaned_df = data.loc[:, existing_columns]
         cleaned_df.dropna(axis=0, how='all', inplace=True)
         return cleaned_df
@@ -243,29 +247,51 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                     or not self.gaschromatographies
                     or not self.potentiometry
                 ):
-                    gc_columns = ['Experiment name', 'Date', 'Time ', 'Gas type', 'RT', 'area', 'ppm value']
+                    gc_columns = [
+                        'Experiment name',
+                        'Date',
+                        'Time ',
+                        'Gas type',
+                        'RT',
+                        'area',
+                        'ppm value',
+                    ]
                     pot_columns = ['time/s', 'I/mA', 'Ewe/V', 'Ece/V', 'Ewe-Ece/V']
-                    thermo_columns = ['Date', 'Time Stamp Local', 'bar(g)', 'øC  cathode', 'øC  anode']
+                    thermo_columns = [
+                        'Date',
+                        'Time Stamp Local',
+                        'bar(g)',
+                        'øC  cathode',
+                        'øC  anode',
+                    ]
                     if len(xls_file.sheet_names) == 4:
                         data = pd.read_excel(xls_file, sheet_name='Raw Data', header=1)
-                        results_data = pd.read_excel(xls_file, sheet_name='Results', header=0)
+                        results_data = pd.read_excel(
+                            xls_file, sheet_name='Results', header=0
+                        )
 
                         gc_data = self.get_cleaned_df(data, gc_columns)
                         pot_data = self.get_cleaned_df(data, pot_columns)
-                        data.columns = data.iloc[1]     # thermo column names are in second row
+                        data.columns = data.iloc[
+                            1
+                        ]  # thermo column names are in second row
                         thermo_data = self.get_cleaned_df(data[2:], thermo_columns)
                     else:
                         pot_data = pd.read_excel(xls_file, sheet_name='Pot Data')
                         thermo_data = pd.read_excel(xls_file, sheet_name='Thermo Data')
                         fid_data = pd.read_excel(xls_file, sheet_name='FID Data')
                         tcd_data = pd.read_excel(xls_file, sheet_name='TCD Data')
-                        results_data = pd.read_excel(xls_file, sheet_name='GC Calc', header=0)
+                        results_data = pd.read_excel(
+                            xls_file, sheet_name='GC Calc', header=0
+                        )
 
                         pot_data = self.get_cleaned_df(pot_data, pot_columns)
                         thermo_data = self.get_cleaned_df(thermo_data, thermo_columns)
                         fid_data = self.get_cleaned_df(fid_data, gc_columns)
                         tcd_data = self.get_cleaned_df(tcd_data, gc_columns)
-                        gc_data = pd.merge(fid_data, tcd_data, on=['Date', 'Time '], how='inner')
+                        gc_data = pd.merge(
+                            fid_data, tcd_data, on=['Date', 'Time '], how='inner'
+                        )
 
                     results_data.dropna(axis=0, how='any', inplace=True)
 
@@ -327,6 +353,7 @@ class CE_NECC_EC_GC(PotentiometryGasChromatographyMeasurement, PlotSection, Entr
                     from nomad_chemical_energy.schema_packages.file_parser.necc_excel_parser import (
                         read_thermocouple_data,
                     )
+
                     try:
                         datetimes, pressure, temperature_cathode, temperature_anode = (
                             read_thermocouple_data(thermo_data, start_time, end_time)

--- a/src/nomad_chemical_energy/schema_packages/file_parser/necc_excel_parser.py
+++ b/src/nomad_chemical_energy/schema_packages/file_parser/necc_excel_parser.py
@@ -144,7 +144,9 @@ def read_results_data(data):
 
 
 def read_properties(file):
-    table_name = 'Experimental details' if len(file.sheet_names) == 4 else 'Experimental Details'
+    table_name = (
+        'Experimental details' if len(file.sheet_names) == 4 else 'Experimental Details'
+    )
     data = pd.read_excel(file, sheet_name=table_name, index_col=0, header=None)
 
     if len(data.columns) == 0:

--- a/src/nomad_chemical_energy/schema_packages/file_parser/necc_excel_parser.py
+++ b/src/nomad_chemical_energy/schema_packages/file_parser/necc_excel_parser.py
@@ -39,7 +39,8 @@ def _process_potentiostat_column(data, column_name):
 
 
 def read_potentiostat_data(data):
-    datetimes = pd.to_datetime(data['time/s'], errors='coerce').dropna()
+    data['time/s'] = pd.to_datetime(data['time/s'], errors='coerce')
+    data = data.dropna(subset=['time/s'])
 
     current = _process_potentiostat_column(data, 'I/mA')
     working_electrode_potential = _process_potentiostat_column(data, 'Ewe/V')
@@ -47,7 +48,7 @@ def read_potentiostat_data(data):
     ewe_ece_difference = _process_potentiostat_column(data, 'Ewe-Ece/V')
 
     return (
-        datetimes,
+        data['time/s'],
         current,
         working_electrode_potential,
         counter_electrode_potential,
@@ -103,9 +104,7 @@ def read_gaschromatography_data(data):
     return instrument_file_names, datetimes, gas_types, retention_times, areas, ppms
 
 
-def read_results_data(file):
-    data = pd.read_excel(file, sheet_name='Results', header=0)
-
+def read_results_data(data):
     data['DateTime'] = pd.to_datetime(data['Time'].astype(str))
     data['Date'] = pd.to_datetime(data['Date'].astype(str))
     data['DateTime'] = data['Date'] + pd.to_timedelta(
@@ -145,9 +144,8 @@ def read_results_data(file):
 
 
 def read_properties(file):
-    data = pd.read_excel(
-        file, sheet_name='Experimental details', index_col=0, header=None
-    )
+    table_name = 'Experimental details' if len(file.sheet_names) == 4 else 'Experimental Details'
+    data = pd.read_excel(file, sheet_name=table_name, index_col=0, header=None)
 
     if len(data.columns) == 0:
         return {}


### PR DESCRIPTION
This PR enables the parsing of Sid's excel file as well as Flora's excel file. The main difference is the structure of the excel files in 4 tabs or in 8 tabs. 
Both files create the same kind of CE-NECC_EC_GC entry.

For files without Thermocouple data the structure of Flora means a smaller file size and therefore faster parsing. When it comes to large amounts of thermocouple data (570000 rows) it is hard to tell the difference. When taking the time the processing of Floras file structure took around 23sec and the old structure around 27sec.