### PR TITLE
Xas kmc3 improvements

### DIFF
--- a/src/nomad_chemical_energy/parsers/ce_nome_parser.py
+++ b/src/nomad_chemical_energy/parsers/ce_nome_parser.py
@@ -48,6 +48,7 @@ from nomad_chemical_energy.schema_packages.ce_nome_package import (
     Bessy2_KMC2_XASFluorescence,
     Bessy2_KMC2_XASTransmission,
     Bessy2_KMC3_XASFluorescence,
+    Bessy2_KMC3_XASTransmission,
     CE_NOME_Chronoamperometry,
     CE_NOME_Chronocoulometry,
     CE_NOME_Chronopotentiometry,
@@ -408,10 +409,17 @@ class XASParser(MatchingParser):
 class KMC3XASParser(MatchingParser):
     def parse(self, mainfile: str, archive: EntryArchive, logger):
         file = mainfile.split('raw/')[-1]
-
-        entry = Bessy2_KMC3_XASFluorescence(data_file=file)
-        entry.datetime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
         file_name_with_folders = file.split('.')[0]
+
+        keywords = ['foil', 'reference', 'trans', 'transmission', 'tm', 'calibration']
+        if any(word.lower() in file_name_with_folders.lower() for word in keywords):
+            entry = Bessy2_KMC3_XASTransmission(data_file=file)
+            entry.method = 'XAS Transmission'
+        else:
+            entry = Bessy2_KMC3_XASFluorescence(data_file=file)
+            entry.method = 'XAS Fluorescence'
+
+        entry.datetime = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
         entry.name = file_name_with_folders
         sample_id = file_name_with_folders.split('/')[-1][:24]
         set_sample_reference(archive, entry, sample_id)

--- a/src/nomad_chemical_energy/schema_packages/ce_nome_package.py
+++ b/src/nomad_chemical_energy/schema_packages/ce_nome_package.py
@@ -717,6 +717,8 @@ class Bessy2_KMC3_XASFluorescence(XASWithSDD, EntryData):
                 get_xas_archive,
             )
             get_xas_archive(data, dateline, self)
+        if self.method is None:
+            self.method = 'XAS Fluorescence'  # for backward compatibility to reprocess old entries
 
         super().normalize(archive, logger)
 

--- a/src/nomad_chemical_energy/schema_packages/ce_nome_package.py
+++ b/src/nomad_chemical_energy/schema_packages/ce_nome_package.py
@@ -716,6 +716,7 @@ class Bessy2_KMC3_XASFluorescence(XASWithSDD, EntryData):
             from baseclasses.helper.archive_builder.xas_archive import (
                 get_xas_archive,
             )
+
             get_xas_archive(data, dateline, self)
         if self.method is None:
             self.method = 'XAS Fluorescence'  # for backward compatibility to reprocess old entries
@@ -756,6 +757,7 @@ class Bessy2_KMC3_XASTransmission(XASWithSDD, EntryData):
             from baseclasses.helper.archive_builder.xas_archive import (
                 get_xas_archive,
             )
+
             get_xas_archive(data, dateline, self)
 
         super().normalize(archive, logger)

--- a/src/nomad_chemical_energy/schema_packages/ce_nome_package.py
+++ b/src/nomad_chemical_energy/schema_packages/ce_nome_package.py
@@ -666,6 +666,23 @@ class Bessy2_KMC2_XASTransmission(XASTransmission, EntryData):
         super().normalize(archive, logger)
 
 
+def get_kmc3_data(file):
+    from nomad_chemical_energy.schema_packages.file_parser.xas_parser import (
+        get_xas_data,
+    )
+
+    prefixes = ['fluo', 'ICR', 'OCR', 'TLT', 'LT', 'RT']
+    header = ['monoE_eV', 'K00', 'K0', 'K1', 'K3'] + [
+        f'{p}.{i}' for p in prefixes for i in range(0, 13)
+    ]
+    first_row = file.readline()
+    if first_row.startswith('#'):
+        header = None
+    file.seek(0)  # reset cursor to use complete file (including first line)
+    data, dateline = get_xas_data(file, header)
+    return data, dateline
+
+
 class Bessy2_KMC3_XASFluorescence(XASWithSDD, EntryData):
     m_def = Section(
         a_eln=dict(
@@ -695,23 +712,48 @@ class Bessy2_KMC3_XASFluorescence(XASWithSDD, EntryData):
     def normalize(self, archive, logger):
         if self.data_file:
             with archive.m_context.raw_file(self.data_file, 'rt') as f:
-                from nomad_chemical_energy.schema_packages.file_parser.xas_parser import (
-                    get_xas_data,
-                )
-
-                prefixes = ['fluo', 'ICR', 'OCR', 'TLT', 'LT', 'RT']
-                header = ['monoE_eV', 'K00', 'K0', 'K1', 'K3'] + [
-                    f'{p}.{i}' for p in prefixes for i in range(0, 13)
-                ]
-                first_row = f.readline()
-                if first_row.startswith('#'):
-                    header = None
-                f.seek(0)  # reset cursor to use complete f (including first line)
-                data, dateline = get_xas_data(f, header)
+                data, dateline = get_kmc3_data(f)
             from baseclasses.helper.archive_builder.xas_archive import (
                 get_xas_archive,
             )
+            get_xas_archive(data, dateline, self)
 
+        super().normalize(archive, logger)
+
+
+class Bessy2_KMC3_XASTransmission(XASWithSDD, EntryData):
+    m_def = Section(
+        a_eln=dict(
+            hide=[
+                'lab_id',
+                'users',
+                'location',
+                'end_time',
+                'steps',
+                'instruments',
+                'results',
+            ],
+            properties=dict(
+                order=[
+                    'name',
+                    'data_file',
+                    'energy',
+                    'k0',
+                    'k1',
+                    'k3',
+                    'samples',
+                ]
+            ),
+        )
+    )
+
+    def normalize(self, archive, logger):
+        if self.data_file:
+            with archive.m_context.raw_file(self.data_file, 'rt') as f:
+                data, dateline = get_kmc3_data(f)
+            from baseclasses.helper.archive_builder.xas_archive import (
+                get_xas_archive,
+            )
             get_xas_archive(data, dateline, self)
 
         super().normalize(archive, logger)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -239,6 +239,7 @@ def test_kmc3_parser_new_header(monkeypatch):
     assert archive.data.energy[0].magnitude == 8.18551
     assert len(archive.data.sdd_parameters[0].fluo) == 483
     assert round(archive.data.sdd_parameters[1].slope, 5) == 1.00108
+    assert archive.data.quality_annotation == 'ICR within specified bounds'
 
 
 def test_kmc3_insitu_biologic_parser(monkeypatch):


### PR DESCRIPTION
Belongs to changes in https://github.com/nomad-hzb/nomad-baseclasses/pull/134

With these changes the reference foil measurements can be saved as `Bessy2_KMC3_XASTransmission` entries and the manual energy shift can be calculated like Marcel suggested. There will be a voila notebook to do this for multiple entries at once ([link to the notebook](https://nomad-hzb-ce.de/nomad-oasis/gui/user/uploads/upload/id/1OmPPM5nSb-Y_g41AdQ66g/files/XAS/xas_manual_energy_shift.ipynb) that still needs the changes to the new entry type). The behavior of the script will be similar to the voltage shift RHE script that we introduced for the summer students this year.